### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,7 +2,7 @@
 
 # Datatypes (KEYWORD1)
 
-AX12A        		KEYWORD1
+AX12A            	KEYWORD1
 
 
 # Methods and Functions (KEYWORD2)
@@ -20,14 +20,14 @@ turn            	KEYWORD2
 moveRW           	KEYWORD2
 moveSpeedRW     	KEYWORD2
 action          	KEYWORD2
-torqueStatus    	KEYWORD2	
+torqueStatus    	KEYWORD2
 ledStatus       	KEYWORD2
 setTempLimit    	KEYWORD2
 setAngleLimit   	KEYWORD2
 setVoltageLimit 	KEYWORD2
 setMaxTorque      	KEYWORD2
 setSRL          	KEYWORD2
-setRDT              KEYWORD2
+setRDT          	KEYWORD2
 setLEDAlarm      	KEYWORD2
 setShutdownAlarm   	KEYWORD2
 setCMargin         	KEYWORD2
@@ -37,14 +37,14 @@ moving            	KEYWORD2
 lockRegister       	KEYWORD2
 RWStatus        	KEYWORD2
 readSpeed        	KEYWORD2
-readLoad            KEYWORD2
+readLoad         	KEYWORD2
 readPosition    	KEYWORD2
 readTemperature 	KEYWORD2
-readVoltage     	KEYWORD2	
+readVoltage     	KEYWORD2
 
 # Constants (LITERAL1)
 
-OFF					LITERAL1
-ON					LITERAL1
+OFF             	LITERAL1
+ON              	LITERAL1
 LEFT            	LITERAL1
 RIGHT           	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords